### PR TITLE
Fixed typo: function -> static

### DIFF
--- a/openweather-based-bidding/classes/utils.gs
+++ b/openweather-based-bidding/classes/utils.gs
@@ -48,7 +48,7 @@ class Utils {
    * @param {!Object} obj
    * @return {boolean}
    */
-  function allObjectPropertiesTrue(obj) {
+  static allObjectPropertiesTrue(obj) {
     return Object.keys(obj).every((k) => obj[k]);
   }
 }


### PR DESCRIPTION
Having the `function` keyword there won't work. Replaced it with `static` as intended.